### PR TITLE
Proposal: Modify the Bystander Training Requirement for Club Leaders

### DIFF
--- a/README.md
+++ b/README.md
@@ -454,7 +454,7 @@
 
     - (b) All officers must be students enrolled in the undergraduate program or the Myra Kraft Transitional Year Program at Brandeis University.
 
-    - (c) All Officers must complete Bystander Training once annually as recorded by the Office of Prevention Services.
+    - (c) All Officers must complete Bystander Training or a Diversity, Equity, and Inclusion Training once annually as recorded by the Office of Prevention Services and the Office of Diversity, Equity, & Inclusion. Failure to comply will result in club de-chartering and de-recognition with the exception of the 2018-2019 academic year.
 
   - **SECTION 9.** Clubs may, with the approval of the Senate, change their names and constitutional purposes. The Chair of the Club Support Committee shall inform the Department of Student Activities of any changes to club names.
 


### PR DESCRIPTION
WHEREAS, there exists a requirement in the Bylaws that club leaders must undergo bystander training,
WHEREAS, the Office of Prevention Services (OPS) requested that the Student Union not enforce the requirement for the 2017-2018 academic year while the office reviewed the training,
WHEREAS, OPS has revised the bystander training curriculum,
WHEREAS, the Office of Diversity, Equity, & Inclusion has developed a workshop on diversity, equity, and inclusion,
WHEREAS, an issue that came up with the original bystander training requirement was that survivors of sexual assault had to reveal themselves in order to receive an exemption from training,
WHEREAS, the option of a diversity, equity, and inclusion training would prevent some club leaders from having to reveal themselves as survivors,
WHEREAS, both bystander training and diversity, equity, and inclusion training would develop valuable intervention skills and awareness for clubs leaders,
WHEREAS, club leaders as leaders and role models on this campus should be well-equipped to lead their groups,
WHEREAS, both OPS and the Office of Diversity, Equity, & Inclusion have willingly agreed to ensure all club leaders are trained in at least one of the trainings,
THEREFORE, “Article VIII: Clubs” of the Student Union Bylaws be amended as proposed herein.

_Sponsored by Hannah Brown, Vice President._