### PR TITLE
Amendment Specifying Judiciary Office Hours

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 
     - (a) Executive Officers shall hold five office hours per week.
 
-    - (b) All Senators, Union Representatives, and Members of the Allocations Board shall hold three office hours per week.
+    - (b) All Senators, Union Representatives, Justices of the Union Judiciary, and Members of the Allocations Board shall hold three office hours per week.
 
   - **SECTION 4.** Student Representatives shall be appointed to University Committees by the Union President, subject to confirmation by the Senate.
   


### PR DESCRIPTION
WHEREAS, all Union Officers must hold weekly office hours (Article II, Section 3),
WHEREAS, Justices of the Union Judiciary are considered Union Officers (Article II, Section 1),
WHEREAS, the Bylaws fail to specify how many office hours Justices must hold,
THEREFORE, be it resolved that Article II, Section 3 of the Student Union Bylaws be amended as follows.

Sponsored by Jake Rong, Senator for Village and 567, and Leigh Salomon, Senator for Ziv and Ridgewood.