### PR TITLE
Amendment Adjusting Reporting Requirement for Senate Committees

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,7 +251,7 @@
 
     - (i) In the event that the Senate Chair of the Committee or the Non-Senate Chair of the Committee fails to adhere to these rules and procedures and/or the duties prescribed to the Senate Committee Chairs in these Bylaws, the President of the Union Senate shall have the authority to remove him/her from the chair position.
 
-    - (j) All Senate Committees must produce a report at least once a year detailing the work they have done as a committee and present it at the Senate meeting prior to Spring Inaugurations.
+    - (j) All Senate Committees must produce a report at least once a semester detailing the work they have done as a committee and present it at the Senate meeting prior to Spring and Fall Inaugurations.
 
   - **SECTION 4.** The Services and Outreach Committee shall address any concerns or issues raised regarding the nature and availability of services provided by the Student Union Senate and foster a stronger relationship between Union officers and the Brandeis Undergraduate Student Body. The committee will also work to connect officers with their constituents, to increase awareness of the role of the Student Union Government, and to publicize and encourage participation in Union projects. These concerns and issues shall include, but not be limited to, the following:
 


### PR DESCRIPTION
WHEREAS, Senate Chairs are appointed for a period of one semester (Article VI, Section 2, Clause B),
WHEREAS, Committees need only produce a report once a year detailing all their work,
WHEREAS, comprehensive Committee reports ought to match the term of the Senate Committee Chair, 
WHEREAS, the rule as it stands reduces Committee Responsibility in the Fall semester,
THEREFORE, be it resolved that Article VI, Section 3, Clause J of these Bylaws be amended as follows.

Sponsored by Jake Rong, Senator for Village and 567, and Leigh Salomon, Senator for Ziv and Ridgewood.