### PR TITLE
Amendment to Require Club Consultants for All Secured Clubs

### DIFF
--- a/README.md
+++ b/README.md
@@ -565,6 +565,25 @@
 
       - (vi) SPS does not work events for off-campus groups or groups unrecognized by Brandeis University.
 
+  - **SECTION 13.** All Secured clubs shall register an official “Club Consultant” with the Senate Club Support Committee and the Department of Student Activities. 
+  
+    - (a) The Club Consultant shall be an employed faculty or staff member at Brandeis University. 
+    
+    - (b) The Club Consultant shall not be a voting member within a club. Student club leaders hold final authority on all club decisions. Club Consultants shall not hold or wield official authority or influence over club operations, content published by media organizations, nor club financial decisions, unless deemed necessary by the organization. 
+    
+    - (c) Club leaders shall host a meeting between the club treasurer and Club Consultant at least twice per semester to ensure consistency with financial policies.
+    
+    - (d) When deemed necessary by student club leaders, Club Consultants shall be contacted for advice on the following matters:
+    
+      - (i) Any leadership or membership issues which arise
+      - (ii) Any inter/intra-group conflict
+      - (iii) Effectively voicing their concerns to administration and advocating for the club 
+      - (iv) Third-party perspectives on club functions and operations
+      - (v) Networking with other universities and off-campus organizations
+      - (vi) Any additional club-related issues that arise
+      
+    - (e) Club leaders shall specify the roles and responsibilities of their respective consultants in their formal contract. These roles and responsibilities shall fall within the constraints of parts (a) through (d). 
+  
 <br>
 
 # ❧ ARTICLE IX: FINANCIAL ACTIVITIES


### PR DESCRIPTION
WHEREAS, student-run organizations at most major universities typically have either a faculty or staff advisor,
WHEREAS, club leaders in the past have suffered from a lack of institutional knowledge and more experienced guidance, 
WHEREAS, the University community repeatedly reports a lack of connection between faculty, staff, and the student body,
WHEREAS, various members of the community, including many club leaders, have requested the creation of a consistent faculty/staff club-advising system,
WHEREAS, secured clubs are regularly allocated the most money from the Student Union, enter into a variety of legal contracts, have the largest membership, and/or occupy the most space on-campus,
THEREFORE, be it resolved that Article VIII, Section 13 of these Bylaws be added as follows.

Sponsored by Noah Nguyen, Senator at-Large, and Aaron Finkel, Senate President.