### PR TITLE
Amendment Repealing Executive Officer Override Power

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@
 
     - (a) Proxy votes are only for amendments, clubs or SMRs which have been discussed at a meeting prior to the vote. This is not applicable to club chartering/recognition votes the day of the meeting.
 
-    - (b) Proxy votes can be overridden by the discretion of the Executive Senator or a ⅔ Senate vote.
+    - (b) Proxy votes can be overridden by a ⅔ Senate vote.
 
   - **SECTION 6.** For each item brought to a vote, there shall be one round of voting. During this round, each member may cast his or her vote only once.
   


### PR DESCRIPTION
WHEREAS, proxy votes are allowed at the discretion of Vice President,
WHEREAS, a proxy vote can already be overridden by a ⅔ Senate vote,
WHEREAS, also allowing the Executive Senator to override a proxy undermines the authority of the Vice President,
THEREFORE, be it resolved that Article 5, Section 5, Clause B of the Student Union Bylaws be amended as follows.

Sponsored by Jake Rong, Senator for Village and 567, and Leigh Salomon, Senator for Ziv and Ridgewood.