### PR TITLE
Amendment Clarifying Appointment of Committee Chairs

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,7 +225,7 @@
 
     - (c) All Senate Chairs may be re-appointed.
 
-    - (d) Senate Chairs for the Fall semester shall be appointed following inaugurations in the Spring and shall take office prior to summer recess.
+    - (d) Senate Chairs for the Fall semester shall be appointed preceding inaugurations in the Spring and shall take office prior to summer recess.
 
     - (e) Senate Chairs for the Spring semester shall be appointed in the Fall semester and take office after Finals conclude.
 


### PR DESCRIPTION
WHEREAS, the Vice President oversees the Senate Committees,
WHEREAS, an incumbent Vice President retains a better understanding of qualified Senate Chairs by nature of already spending a term working with said Senators,
WHEREAS, it makes little sense for a new Vice President to choose Senate Chairs before becoming acquainted with Senators,
WHEREAS, in the past, new Vice Presidents have needed to spend multiple weeks at the beginning of a new school year becoming acquainted with Senators before choosing Chairs,
WHEREAS, this traditional process has led to delays in committee progress at the start of new school years,
WHEREAS, this does not remove any autonomy from the newly elected Vice President but simply shifts the timeline (newly elected VP appoints or re-appoints Chairs at his or her discretion at the end of his or her first semester as VP and appoints or re-appoints Chairs for the next semester, i.e., next new VP, at the end of his or her second semester as VP),
WHEREAS, the new Vice President still retains the right to remove unqualified Chairs (and so, still retains autonomy),
WHEREAS, this does not affect the eligibility of the incumbent Off-Campus or Quad Senators because 1) their terms continue until the third round of elections and subsequent inaugurations in fall of the following semester (Constitution: Article IX, Section 4, Clause 2) and 2) regardless of this amendment, Senate Chairs are still supposed to be appointed and take office in the spring, before the new Off-Campus and Quad Senators are elected,
THEREFORE, be it resolved that Article VI, Section 2, Clause D of the Student Union Bylaws be amended as follows.

Sponsored by Jake Rong, Senator for Village and 567, Leigh Salomon, Senator for Ziv and Ridgewood, and Nancy Zhai, Senator to the Class of 2022.