### PR TITLE
Amendment Granting Student Union Senators The Ability to Enforce The …

### DIFF
--- a/README.md
+++ b/README.md
@@ -747,9 +747,9 @@
       
       - (k) The secretary shall ensure that all members of the Student Union sign the Union Oath of Office (in addition to any verbal/ceremonial oath). This signature shall be kept as a public record of their acknowledgement of their responsibilities to the Union and to their Constituents.  
       
-  - **SECTION 2.** Failure to uphold these standards may result in one or more of the following:
+  - **SECTION 2.** Failure to uphold these standards shall grant any Union Officer the right to submit a request to the Senate (in accordance with Article V, Section 3 of these Bylaws) to impose, subject to a 2/3 vote of the Senate,one or more of the following:
   
-      - (a) Revocation of Student Union Office/Romper Room Access/Privileges (at the discretion of the Student Union Secretary and President) 
+      - (a) Revocation of Student Union Office/Romper Room Access/Privileges 
       
       - (b) Referral to the Student Union Chief of Staff 
       


### PR DESCRIPTION
…Student Union Code of Conduct

Whereas the Code of Conduct was created to hold all Union Officers accountable to their Constitutional duties and maintain decorum and conduct consistent with Robert’s Rules,
Whereas, the Code of Conduct fails to specify who enforces it and if the Senate needs to approve any action taken, 
Therefore, be it resolved that Article XI, Section 2 of the Student Union Bylaws be amended as follows.

Respectfully Submitted by,
Leigh Salomon
Former Ziv and Ridgewood Senator 
Jake Rong 
Executive Senator; Senator to the Class of 2021