### PR TITLE
Amendment Mandating that Senators Hold Office Hours by Appointment Only

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,8 @@
 
     - (a) Executive Officers shall hold five office hours per week.
 
-    - (b) All Senators, Union Representatives, Justices of the Union Judiciary, and Members of the Allocations Board shall hold three office hours per week.
+    - (b) All Union Representatives, Justices of the Union Judiciary, and Members of the Allocations Board shall hold three office hours per week.
+    -(c) All Senators shall hold office hours by appointment
 
   - **SECTION 4.** Student Representatives shall be appointed to University Committees by the Union President, subject to confirmation by the Senate.
   


### PR DESCRIPTION
Whereas Article II, Section 3, subsection b of the Student Union bylaws states that all Senators shall hold three office hours a week;
Whereas this statute is designed to allow Senators to hear from their constituents in order to properly represent them, as described in Article II, Section 1 on the Constitution;
Whereas many Senators receive little or no feedback from Constituents during their office hours;
Whereas constituents should still be afforded the opportunity to meet with their representatives;
Therefore, Article II, Section 3, of the Student Union Bylaws shall be amended as follows:

Respectfully Submitted, 
Scott Halper 
Senator to the Class of 2020